### PR TITLE
Add live TLS certificate check feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This tool helps you gather domains, organizations, and addresses from X.509 cert
 - Supports multiple query types:  `=`, `ILIKE`, `LIKE`, `single`, `any`, `FTS`
 - Save the results in JSON format
 - Cross-platform support (Linux, macOS, Windows)
+- Live certificate inspection for any domain
 
 ## Installation
 
@@ -44,6 +45,7 @@ mv cert-cli /usr/local/bin
 ## Usage
 ```bash
 cert-cli -q "<company or domain>" -match "<query-type>" -o <output-file> -proxy "<proxy-url>"
+cert-cli -d "<domain>" -o <output-file>
 ```
 
 ### Flags
@@ -51,11 +53,12 @@ cert-cli -q "<company or domain>" -match "<query-type>" -o <output-file> -proxy 
 - `-match`: The query type to use. Supported values are `LIKE`, `ANY`, `ILIKE`
 - `-o`: The output file to save the results in JSON format
 - `-proxy`: The proxy URL to use for the request
+- `-d`: Perform a live TLS check for the specified domain
 
 ### Example Commands
 Search for certificates for `Dreamwors` with the match type `LIKE`:
 ```bash
-cert-cli -q "Dreamworks" -match "LIKE" 
+cert-cli -q "Dreamworks" -match "LIKE"
 
 # Output
 [i] Fetching feed: https://crt.sh/atom?q=Dreamworks&match=LIKE
@@ -101,6 +104,11 @@ Found:
   - northcarolina.win.dreamworks.com
   - dreamworksanimation.com
   - devilrays.win.dreamworks.com
+```
+
+Check the currently served certificate for `example.com`:
+```bash
+cert-cli -d example.com
 ```
 
 Should you need to save the results in a file, you can use the `-o` flag:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/mihneamanolache/cert-cli/internal/feed"
+	"github.com/mihneamanolache/cert-cli/internal/live"
 	"github.com/mihneamanolache/cert-cli/internal/types"
 	"github.com/mihneamanolache/cert-cli/internal/utils"
 	"log"
@@ -13,28 +14,52 @@ import (
 func main() {
 	// Parse command-line flags
 	query := flag.String("q", "", "organization to search for in the certificate's subject field")
+	domain := flag.String("d", "", "perform live check for domain")
 	match := flag.String("match", "LIKE", "Match type (allowed values: =, ILIKE, LIKE, single, any, FTS)")
 	proxy := flag.String("proxy", "", "proxy")
 	jsonOutput := flag.String("o", "", "save findings to JSON file")
 	flag.Parse()
+
+	if *domain != "" {
+		certInfo, err := live.CheckDomain(*domain)
+		if err != nil {
+			log.Fatalf(types.Red+"Error checking domain: %v"+types.Reset, err)
+		}
+		utils.PrintCertificate(certInfo)
+		if *jsonOutput != "" {
+			results := types.QueryResult{
+				Query:        *domain,
+				URL:          *domain,
+				Certificates: []types.Certificate{certInfo},
+			}
+			file, err := os.Create(fmt.Sprintf("%s.json", *jsonOutput))
+			if err != nil {
+				log.Fatalf(types.Red+"Error creating JSON file: %v"+types.Reset, err)
+			}
+			defer file.Close()
+			utils.SaveToJSON(file, results)
+			fmt.Println(types.Yellow + "\n[i] Findings have been saved to " + file.Name() + types.Reset)
+		}
+		return
+	}
 
 	if *query == "" {
 		log.Fatalf(types.Red + "You must provide a query using --q flag" + types.Reset)
 	}
 
 	feedURL := feed.ConstructFeedURL(*query, *match)
-	fmt.Printf(types.Bold + "[i] Fetching feed: %s\n" + types.Reset, feedURL)
+	fmt.Printf(types.Bold+"[i] Fetching feed: %s\n"+types.Reset, feedURL)
 	atomFeed, err := feed.FetchFeedWithRetry(feedURL, 3, *proxy)
 	if err != nil {
-		log.Fatalf(types.Red + "Error fetching feed: %v" + types.Reset, err)
+		log.Fatalf(types.Red+"Error fetching feed: %v"+types.Reset, err)
 	}
 
 	certificates, entryURLs := feed.ProcessFeed(atomFeed)
 
-	fmt.Printf(types.Bold + "[i] Query: %s\n" + types.Reset, *query)
+	fmt.Printf(types.Bold+"[i] Query: %s\n"+types.Reset, *query)
 	fmt.Printf("[i] Parsed %d certificates\n\n", len(entryURLs))
 
-    utils.PrintResults(certificates)
+	utils.PrintResults(certificates)
 
 	// Save results to JSON if requested
 	if *jsonOutput != "" {
@@ -46,7 +71,7 @@ func main() {
 
 		file, err := os.Create(fmt.Sprintf("%s.json", *jsonOutput))
 		if err != nil {
-			log.Fatalf(types.Red + "Error creating JSON file: %v" + types.Reset, err)
+			log.Fatalf(types.Red+"Error creating JSON file: %v"+types.Reset, err)
 		}
 		defer file.Close()
 
@@ -54,4 +79,3 @@ func main() {
 		fmt.Println(types.Yellow + "\n[i] Findings have been saved to " + file.Name() + types.Reset)
 	}
 }
-

--- a/internal/live/live.go
+++ b/internal/live/live.go
@@ -1,0 +1,70 @@
+package live
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"github.com/mihneamanolache/cert-cli/internal/types"
+	"strings"
+	"time"
+)
+
+// CheckDomain performs a TLS connection to the given domain and returns
+// parsed certificate information.
+func CheckDomain(domain string) (types.Certificate, error) {
+	conn, err := tls.Dial("tcp", domain+":443", &tls.Config{
+		ServerName:         domain,
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		return types.Certificate{}, err
+	}
+	defer conn.Close()
+
+	state := conn.ConnectionState()
+	if len(state.PeerCertificates) == 0 {
+		return types.Certificate{}, fmt.Errorf("no certificate presented")
+	}
+
+	cert := state.PeerCertificates[0]
+
+	var keyUsage []string
+	if cert.KeyUsage&x509.KeyUsageDigitalSignature != 0 {
+		keyUsage = append(keyUsage, "Digital Signature")
+	}
+	if cert.KeyUsage&x509.KeyUsageKeyEncipherment != 0 {
+		keyUsage = append(keyUsage, "Key Encipherment")
+	}
+
+	address := strings.Join(filterNonEmpty([]string{
+		strings.Join(cert.Subject.PostalCode, " "),
+		strings.Join(cert.Subject.StreetAddress, " "),
+		strings.Join(cert.Subject.Province, " "),
+		strings.Join(cert.Subject.Country, " "),
+	}), " ")
+
+	return types.Certificate{
+		URL:                domain,
+		Organization:       strings.Join(cert.Subject.Organization, ", "),
+		CommonName:         cert.Subject.CommonName,
+		SAN:                cert.DNSNames,
+		Address:            address,
+		Issuer:             cert.Issuer.CommonName,
+		SerialNumber:       cert.SerialNumber.String(),
+		NotBefore:          cert.NotBefore.Format(time.RFC3339),
+		NotAfter:           cert.NotAfter.Format(time.RFC3339),
+		KeyUsage:           keyUsage,
+		SignatureAlgorithm: cert.SignatureAlgorithm.String(),
+		Version:            cert.Version,
+	}, nil
+}
+
+func filterNonEmpty(parts []string) []string {
+	var result []string
+	for _, part := range parts {
+		if strings.TrimSpace(part) != "" {
+			result = append(result, part)
+		}
+	}
+	return result
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -5,17 +5,17 @@ import (
 	"fmt"
 	"github.com/mihneamanolache/cert-cli/internal/types"
 	"io"
-    "strings"
+	"strings"
 )
 
 // escapeXML replaces special characters with their corresponding XML escape codes.
 func EscapeXML(input string) string {
-    replacer := strings.NewReplacer(
-		// "&", "&amp;",
-		// "<", "&lt;",
-		// ">", "&gt;",
-		// "\"", "&quot;",
-		// "'", "&apos;",
+	replacer := strings.NewReplacer(
+	// "&", "&amp;",
+	// "<", "&lt;",
+	// ">", "&gt;",
+	// "\"", "&quot;",
+	// "'", "&apos;",
 	)
 	return replacer.Replace(input)
 }
@@ -110,4 +110,26 @@ func PrintResults(certificates []types.Certificate) {
 	} else {
 		fmt.Println("  - None")
 	}
+}
+
+// PrintCertificate displays detailed information for a single certificate.
+func PrintCertificate(cert types.Certificate) {
+	fmt.Println(types.Bold + "Certificate:" + types.Reset)
+	fmt.Printf("  Organization: %s\n", cert.Organization)
+	fmt.Printf("  Common Name: %s\n", cert.CommonName)
+	if len(cert.SAN) > 0 {
+		fmt.Printf("  SANs: %s\n", strings.Join(cert.SAN, ", "))
+	}
+	if cert.Address != "" {
+		fmt.Printf("  Address: %s\n", cert.Address)
+	}
+	fmt.Printf("  Issuer: %s\n", cert.Issuer)
+	fmt.Printf("  Serial Number: %s\n", cert.SerialNumber)
+	fmt.Printf("  Not Before: %s\n", cert.NotBefore)
+	fmt.Printf("  Not After: %s\n", cert.NotAfter)
+	if len(cert.KeyUsage) > 0 {
+		fmt.Printf("  Key Usage: %s\n", strings.Join(cert.KeyUsage, ", "))
+	}
+	fmt.Printf("  Signature Algorithm: %s\n", cert.SignatureAlgorithm)
+	fmt.Printf("  Version: %d\n", cert.Version)
 }


### PR DESCRIPTION
## Summary
- add `-d` flag to check certificate directly from a live domain
- implement certificate fetch logic in new `live` package
- support JSON output for live checks
- print single certificate details
- document new option and usage

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_68531451fab4832caf21bd880a3658c2